### PR TITLE
Remove Playwright snapshots and refactor tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,10 @@ web_modules/
 # Output of 'npm pack'
 *.tgz
 
+# Playwright test artifacts
+test-results/
+tests/landing.spec.js-snapshots/
+
 # Yarn Integrity file
 .yarn-integrity
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,10 @@ These instructions apply to the entire repository.
 - Keep DOM manipulation minimal and avoid polluting the global scope.
 
 ## Workflow
-1. After modifying files, run `npm test` to ensure everything passes.
-2. Document rationale in comments where code may be non-obvious.
-3. Keep JavaScript modular and well-documented.
+1. Update or add tests whenever code changes to keep coverage current.
+2. After modifying files, run `npm test` to ensure everything passes.
+3. Document rationale in comments where code may be non-obvious.
+4. Keep JavaScript modular and well-documented.
 
 ## Commit Standards
 - Commit messages should be in present tense and imperative mood (e.g., "Add

--- a/index.html
+++ b/index.html
@@ -3,6 +3,39 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta
+    name="description"
+    content="Vocalis turns fragmented speech into full expression with AI communication."
+  />
+  <link rel="canonical" href="https://vocalis.app/" />
+  <meta
+    name="keywords"
+    content="augmentative communication apps, AAC app, speech disability communication,
+    ALS communication app"
+  />
+  <meta property="og:title" content="Vocalis – From Fragments to Full Expression" />
+  <meta
+    property="og:description"
+    content="AI-powered AAC app for speech disabilities including ALS."
+  />
+  <meta property="og:url" content="https://vocalis.app/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Vocalis – From Fragments to Full Expression" />
+  <meta
+    name="twitter:description"
+    content="AI-powered augmentative and alternative communication app for expressive speech."
+  />
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "Vocalis",
+      "operatingSystem": "Web",
+      "applicationCategory": "CommunicationApplication",
+      "description": "AI-powered AAC app for speech disabilities."
+    }
+  </script>
   <title>Vocalis – From Fragments to Full Expression</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -133,7 +166,7 @@
   </style>
 </head>
 <body>
-  <div id="app">
+  <main id="app">
     <nav class="logo-header">
       <img id="logo" alt="Vocalis logo" />
     </nav>
@@ -282,7 +315,62 @@
         fragments into expressive speech—not just clarity, but character.
       </p>
     </section>
-  </div>
+    <section>
+      <h2>Assistive Communication for Everyone</h2>
+      <p>
+        Vocalis is an AI-powered augmentative and alternative communication (AAC) app for
+        speech disabilities including ALS, cerebral palsy, stroke, and apraxia.
+      </p>
+      <p>
+        This speech disability communication app turns fragments into fluent speech, giving
+        caregivers and therapists a modern AAC tool.
+      </p>
+      <p>
+        The ALS community and others benefit from a flexible AAC app that respects personal
+        style.
+      </p>
+    </section>
+
+    <section>
+      <h2>Market Opportunity</h2>
+      <p>
+        Over 40 million people worldwide rely on AAC tools, a market projected to surpass
+        $5 billion by 2030.
+      </p>
+      <p>
+        Vocalis targets this gap with an AI-first approach, unlocking new demand across
+        clinical, education, and consumer channels.
+      </p>
+    </section>
+
+    <section>
+      <h2>Business Model</h2>
+      <p>
+        Freemium access lowers barriers while tiered subscriptions offer advanced voices,
+        analytics, and caregiver collaboration.
+      </p>
+      <p>
+        Licensing partnerships with clinics and device makers compound recurring revenue
+        streams.
+      </p>
+    </section>
+
+    <section>
+      <h2>Roadmap</h2>
+      <p>
+        Beta launches with core text-to-speech in Q1 2025, followed by gesture input,
+        multilingual voices, and offline support.
+      </p>
+    </section>
+
+    <section>
+      <h2>Team</h2>
+      <p>
+        Built by speech-language pathologists and AI researchers, the team blends clinical
+        insight with scalable engineering.
+      </p>
+    </section>
+  </main>
 
   <footer>
     © <span id="year"></span> Vocalis. All rights reserved.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,102 @@
+{
+  "name": "vocalis",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vocalis",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@axe-core/playwright": "^4.7.3",
+        "@playwright/test": "^1.42.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz",
+      "integrity": "sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.10.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "Placeholder package to enable npm tests",
   "scripts": {
-    "test": "echo \"No tests\""
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^4.7.3",
+    "@playwright/test": "^1.42.0"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests',
+  use: {
+    trace: 'on-first-retry'
+  }
+});

--- a/tests/landing.spec.js
+++ b/tests/landing.spec.js
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { AxeBuilder } from '@axe-core/playwright';
+
+const fileUrl = 'file://' + path.join(__dirname, '..', 'index.html');
+
+const viewports = [
+  { name: 'mobile-portrait', width: 375, height: 667 },
+  { name: 'mobile-landscape', width: 667, height: 375 },
+  { name: 'tablet-portrait', width: 768, height: 1024 },
+  { name: 'tablet-landscape', width: 1024, height: 768 },
+  { name: 'desktop', width: 1280, height: 800 }
+];
+
+for (const vp of viewports) {
+  test(`render ${vp.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: vp.width, height: vp.height });
+    await page.goto(fileUrl);
+    await expect(page).toHaveTitle(/Vocalis/);
+    await expect(page.locator('h1')).toBeVisible();
+    await expect(page.getByText('Join the Waitlist')).toBeVisible();
+  });
+}
+
+test('has SEO essentials', async ({ page }) => {
+  await page.goto(fileUrl);
+  const description = await page.locator('meta[name="description"]').getAttribute('content');
+  expect(description).toBeTruthy();
+  const keywords = await page.locator('meta[name="keywords"]').getAttribute('content');
+  expect(keywords).toBeTruthy();
+  const canonical = await page.locator('link[rel="canonical"]').getAttribute('href');
+  expect(canonical).toBeTruthy();
+  await expect(page.locator('h1')).toBeVisible();
+});
+
+test('is accessible', async ({ page }) => {
+  await page.goto(fileUrl);
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});
+
+test('includes investor sections', async ({ page }) => {
+  await page.goto(fileUrl);
+  await expect(page.getByRole('heading', { name: 'Market Opportunity' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Business Model' })).toBeVisible();
+});
+


### PR DESCRIPTION
## Summary
- ignore `tests/landing.spec.js-snapshots/` to keep binary baselines out of version control
- verify Join the Waitlist button in viewport tests instead of relying on screenshots

## Testing
- `npm ci`
- `npx playwright install`
- `npx playwright install-deps`
- `npm test`
```
> vocalis@1.0.0 test
> playwright test

Running 8 tests using 1 worker

  ✓ 1 tests/landing.spec.js:16:7 › render mobile-portrait (370ms)
  ✓ 2 tests/landing.spec.js:16:7 › render mobile-landscape (269ms)
  ✓ 3 tests/landing.spec.js:16:7 › render tablet-portrait (239ms)
  ✓ 4 tests/landing.spec.js:16:7 › render tablet-landscape (252ms)
  ✓ 5 tests/landing.spec.js:16:7 › render desktop (253ms)
  ✓ 6 tests/landing.spec.js:25:5 › has SEO essentials (233ms)
  ✓ 7 tests/landing.spec.js:36:5 › is accessible (1.5s)
  ✓ 8 tests/landing.spec.js:42:5 › includes investor sections (224ms)

  8 passed (5.4s)
```


------
https://chatgpt.com/codex/tasks/task_e_68b5476399908320b5476f807ba949aa